### PR TITLE
fix: fix proc-macro out of bounds panic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,10 +13,17 @@ repository = "https://github.com/lilopkins/lnk-rs"
 
 [features]
 default = ["serde"]
-binwrite = [ "stability" ]
+binwrite = ["stability"]
 unstable-save = []
 serde = ["dep:serde", "dep:serde_json", "bitflags/serde"]
-lnk2json = ["serde", "dep:clap", "dep:simplelog", "dep:clap-verbosity-flag", "dep:clio", "dep:anyhow"]
+lnk2json = [
+    "serde",
+    "dep:clap",
+    "dep:simplelog",
+    "dep:clap-verbosity-flag",
+    "dep:clio",
+    "dep:anyhow",
+]
 
 [[bin]]
 name = "lnk2json"
@@ -35,7 +42,7 @@ required-features = ["binwrite"]
 
 [dependencies]
 log = "0.4.11"
-bitflags = "2.4"
+bitflags = "2.8"
 chrono = "0.4.23"
 num-traits = "0.2.14"
 num-derive = "0.4"
@@ -50,13 +57,17 @@ substring = "1.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
-clap = { version = "4", features = ["derive", "wrap_help", "cargo"], optional = true }
+clap = { version = "4", features = [
+    "derive",
+    "wrap_help",
+    "cargo",
+], optional = true }
 simplelog = { version = "0.12", optional = true }
 clap-verbosity-flag = { version = "3.0.2", optional = true }
 clio = { version = "0.3", features = ["clap-parse"], optional = true }
 anyhow = { version = "1.0", optional = true }
 
-stability = {version = "0.2.1", optional = true }
+stability = { version = "0.2.1", optional = true }
 
 [dev-dependencies]
 pretty_env_logger = "0.5.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,7 @@ default = ["serde"]
 binwrite = ["stability"]
 unstable-save = []
 serde = ["dep:serde", "dep:serde_json", "bitflags/serde"]
-lnk2json = [
-    "serde",
-    "dep:clap",
-    "dep:simplelog",
-    "dep:clap-verbosity-flag",
-    "dep:clio",
-    "dep:anyhow",
-]
+lnk2json = ["serde", "dep:clap", "dep:simplelog", "dep:clap-verbosity-flag", "dep:clio", "dep:anyhow"]
 
 [[bin]]
 name = "lnk2json"
@@ -57,11 +50,7 @@ substring = "1.4"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_json = { version = "1", optional = true }
 
-clap = { version = "4", features = [
-    "derive",
-    "wrap_help",
-    "cargo",
-], optional = true }
+clap = { version = "4", features = ["derive", "wrap_help", "cargo"], optional = true }
 simplelog = { version = "0.12", optional = true }
 clap-verbosity-flag = { version = "3.0.2", optional = true }
 clio = { version = "0.3", features = ["clap-parse"], optional = true }

--- a/src/linkinfo.rs
+++ b/src/linkinfo.rs
@@ -140,8 +140,7 @@ pub struct LinkInfo {
     /// CommonPathSuffixOffset (4 bytes): A 32-bit, unsigned integer that
     /// specifies the location of the CommonPathSuffix field. This value is
     /// an offset, in bytes, from the start of the LinkInfo structure.
-    #[br(assert(common_path_suffix_offset < link_info_size &&
-                common_path_suffix_offset >= link_info_header_size))]
+    #[br(assert(common_path_suffix_offset < link_info_size && common_path_suffix_offset >= link_info_header_size))]
     common_path_suffix_offset: u32,
 
     /// LocalBasePathOffsetUnicode (4 bytes): An optional, 32-bit, unsigned


### PR DESCRIPTION
Fixes a very weird proc-macro panic in `binrw` I encountered while trying to use your library.
For some reason, the `binrw` crate doesn't allow newlines in that condition (introduced in 78db9fbf9d465ef798388877496a822953d1d911).
Also updated the `bitflags` crate to the latest version, but I can revert that if you wish.